### PR TITLE
Use version 1 for the Google KMS key

### DIFF
--- a/src/key/handlers/GoogleFederatedKeyHandler/index.ts
+++ b/src/key/handlers/GoogleFederatedKeyHandler/index.ts
@@ -29,7 +29,7 @@ export class GoogleFederatedKeyHandler implements KeyHandler {
       config.location,
       config.keyRingId,
       config.keyId,
-      "latest"
+      "1"
     );
   }
 


### PR DESCRIPTION
This PR fixes a bug where `latest` cannot be used for a key version